### PR TITLE
Fix issue #4 by creating a new Nokogiri::XML object before xpath query.

### DIFF
--- a/rules.rb
+++ b/rules.rb
@@ -27,7 +27,7 @@ rule "ETSY004", "Execute resource defined without conditional or action :nothing
   recipe do |ast,filename|
     pres = find_resources(ast, :type => 'execute').find_all do |cmd|
       cmd_actions = (resource_attribute(cmd, 'action') || resource_name(cmd)).to_s
-      condition = cmd.xpath('//ident[@value="only_if" or @value="not_if" or @value="creates"][parent::fcall or parent::command or ancestor::if]')
+      condition = Nokogiri::XML(cmd.to_xml).xpath('//ident[@value="only_if" or @value="not_if" or @value="creates"][parent::fcall or parent::command or ancestor::if]')
       (condition.empty? && !cmd_actions.include?("nothing"))
     end.map{|cmd| match(cmd)}
   end


### PR DESCRIPTION
I noticed that if you xpath query objects returned from find_resources(ast).find_all, you end up querying the whole ast. That's the reason for this issue.

Sometimes a line of code is worth than 1000 words, so...

for instance, this:

``` ruby
find_resources(ast, :type => 'execute').find_all do |cmd|
  result = cmd.xpath('//')
end
```

has the same result as this:

``` ruby
find_resources(ast, :type => 'execute').find_all do |cmd|
  result = ast.xpath('//')
end
```

That's why i decided to build a new Nokogiri::XML object with the cmd XML.
