### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#foodcritic-rules
+# foodcritic-rules
 ================
 
 These are the foodcritic rules we've written here at Etsy to enforce rules on our cookbooks. Some of these rules are  best practices we've identified for our particular use case, and some were put in place as remediation items after issues we experienced.


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
